### PR TITLE
Added IsInfinity() and Equal() functions.

### DIFF
--- a/extra.go
+++ b/extra.go
@@ -29,3 +29,57 @@ func (p *P521Point) Negate(q *P521Point) *P521Point {
 	p.z.Set(q.z)
 	return p
 }
+
+// IsInfinity returns 1 if p is the point-at-infinity, 0 otherwise.
+func (p *P224Point) IsInfinity() int {
+	return p.z.IsZero()
+}
+
+// IsInfinity returns 1 if p is the point-at-infinity, 0 otherwise.
+func (p *P384Point) IsInfinity() int {
+	return p.z.IsZero()
+}
+
+// IsInfinity returns 1 if p is the point-at-infinity, 0 otherwise.
+func (p *P521Point) IsInfinity() int {
+	return p.z.IsZero()
+}
+
+// Equal returns 1 if p and q represent the same point, 0 otherwise.
+func (p *P224Point) Equal(q *P224Point) int {
+	pinf := p.z.IsZero()
+	qinf := q.z.IsZero()
+	bothinf := pinf & qinf
+	noneinf := (1 - pinf) & (1 - qinf)
+	px := new(fiat.P224Element).Mul(p.x, q.z)
+	qx := new(fiat.P224Element).Mul(q.x, p.z)
+	py := new(fiat.P224Element).Mul(p.y, q.z)
+	qy := new(fiat.P224Element).Mul(q.y, p.z)
+	return bothinf | (noneinf & px.Equal(qx) & py.Equal(qy))
+}
+
+// Equal returns 1 if p and q represent the same point, 0 otherwise.
+func (p *P384Point) Equal(q *P384Point) int {
+	pinf := p.z.IsZero()
+	qinf := q.z.IsZero()
+	bothinf := pinf & qinf
+	noneinf := (1 - pinf) & (1 - qinf)
+	px := new(fiat.P384Element).Mul(p.x, q.z)
+	qx := new(fiat.P384Element).Mul(q.x, p.z)
+	py := new(fiat.P384Element).Mul(p.y, q.z)
+	qy := new(fiat.P384Element).Mul(q.y, p.z)
+	return bothinf | (noneinf & px.Equal(qx) & py.Equal(qy))
+}
+
+// Equal returns 1 if p and q represent the same point, 0 otherwise.
+func (p *P521Point) Equal(q *P521Point) int {
+	pinf := p.z.IsZero()
+	qinf := q.z.IsZero()
+	bothinf := pinf & qinf
+	noneinf := (1 - pinf) & (1 - qinf)
+	px := new(fiat.P521Element).Mul(p.x, q.z)
+	qx := new(fiat.P521Element).Mul(q.x, p.z)
+	py := new(fiat.P521Element).Mul(p.y, q.z)
+	qy := new(fiat.P521Element).Mul(q.y, p.z)
+	return bothinf | (noneinf & px.Equal(qx) & py.Equal(qy))
+}

--- a/extra_asm.go
+++ b/extra_asm.go
@@ -21,3 +21,41 @@ func (p *P256Point) Negate(q *P256Point) *P256Point {
 	p.z = q.z
 	return p
 }
+
+// IsInfinity returns 1 if p is the point-at-infinity, 0 otherwise.
+func (p *P256Point) IsInfinity() int {
+	return p.isInfinity()
+}
+
+// Equal returns 1 if p and q represent the same point, 0 otherwise.
+func (p *P256Point) Equal(q *P256Point) int {
+	pinf := p256Equal(&p.z, &p256Zero)
+	qinf := p256Equal(&q.z, &p256Zero)
+	bothinf := pinf & qinf
+	noneinf := (1 - pinf) & (1 - qinf)
+
+	// xp = Xp / Zp²
+	// yp = Yp / Zp³
+	// xq = Xq / Zq²
+	// yq = Yq / Zq³
+	// If Zp != 0 and Zq != 0, then:
+	//    xp == yp  <=>  Xp*Zq² == Xq*Zp²
+	//    xq == yq  <=>  Yp*Zq³ == Yq*Zp³
+	px := new(p256Element)
+	qx := new(p256Element)
+	py := new(p256Element)
+	qy := new(p256Element)
+	pz := new(p256Element)
+	qz := new(p256Element)
+	p256Sqr(pz, &p.z, 1)
+	p256Sqr(qz, &q.z, 1)
+	p256Mul(px, &p.x, qz)
+	p256Mul(qx, &q.x, pz)
+	samex := p256Equal(px, qx)
+	p256Mul(pz, pz, &p.z)
+	p256Mul(qz, qz, &q.z)
+	p256Mul(py, &p.y, qz)
+	p256Mul(qy, &q.y, pz)
+	samey := p256Equal(py, qy)
+	return bothinf | (noneinf & samex & samey)
+}

--- a/extra_noasm.go
+++ b/extra_noasm.go
@@ -15,3 +15,21 @@ func (p *P256Point) Negate(q *P256Point) *P256Point {
 	p.z.Set(q.z)
 	return p
 }
+
+// IsInfinity returns 1 if p is the point-at-infinity, 0 otherwise.
+func (p *P256Point) IsInfinity() int {
+	return p.z.IsZero()
+}
+
+// Equal returns 1 if p and q represent the same point, 0 otherwise.
+func (p *P256Point) Equal(q *P256Point) int {
+	pinf := p.z.IsZero()
+	qinf := q.z.IsZero()
+	bothinf := pinf & qinf
+	noneinf := (1 - pinf) & (1 - qinf)
+	px := new(fiat.P256Element).Mul(p.x, q.z)
+	qx := new(fiat.P256Element).Mul(q.x, p.z)
+	py := new(fiat.P256Element).Mul(p.y, q.z)
+	qy := new(fiat.P256Element).Mul(q.y, p.z)
+	return bothinf | (noneinf & px.Equal(qx) & py.Equal(qy))
+}

--- a/extra_test.go
+++ b/extra_test.go
@@ -17,11 +17,14 @@ type nistPointExtra[T any] interface {
 	Bytes() []byte
 	SetGenerator() T
 	SetBytes([]byte) (T, error)
+	Set(T) T
 	Add(T, T) T
 	Double(T) T
 	Negate(T) T
 	ScalarMult(T, []byte) (T, error)
 	ScalarBaseMult([]byte) (T, error)
+	IsInfinity() int
+	Equal(T) int
 }
 
 func TestNegate(t *testing.T) {
@@ -55,5 +58,110 @@ func testNegate[P nistPointExtra[P]](t *testing.T, newPoint func() P, c elliptic
 	p.Negate(p)
 	if !bytes.Equal(p.Bytes(), p1.Bytes()) {
 		t.Error("-P (aliasing) != -P")
+	}
+}
+
+func TestEqual(t *testing.T) {
+	t.Run("P224", func(t *testing.T) {
+		testEqual(t, nistec.NewP224Point, elliptic.P224())
+	})
+	t.Run("P256", func(t *testing.T) {
+		testEqual(t, nistec.NewP256Point, elliptic.P256())
+	})
+	t.Run("P384", func(t *testing.T) {
+		testEqual(t, nistec.NewP384Point, elliptic.P384())
+	})
+	t.Run("P521", func(t *testing.T) {
+		testEqual(t, nistec.NewP521Point, elliptic.P521())
+	})
+}
+
+func testEqual[P nistPointExtra[P]](t *testing.T, newPoint func() P, c elliptic.Curve) {
+	inf := newPoint()
+	g := newPoint().SetGenerator()
+	g.Add(g, g)
+	if inf.Equal(inf) != 1 {
+		t.Error("inf != inf")
+	}
+	if g.Equal(g) != 1 {
+		t.Error("G != G")
+	}
+	if inf.Equal(g) != 0 || g.Equal(inf) != 0 {
+		t.Error("G == inf")
+	}
+	p1 := newPoint().Set(g)
+	p2 := newPoint()
+	p3 := newPoint()
+	sc := make([]byte, (c.Params().N.BitLen()+7)>>3)
+	for i := 1; i < 30; i++ {
+		sc[len(sc)-1] = byte(i)
+		_, err := p2.ScalarMult(g, sc)
+		fatalIfErr(t, err)
+		sc[len(sc)-1] = byte(i * 2)
+		_, err = p3.ScalarBaseMult(sc)
+		fatalIfErr(t, err)
+		if p1.Equal(p2) != 1 || p2.Equal(p1) != 1 {
+			t.Error("n*G != n*G (1)")
+		}
+		if p1.Equal(p3) != 1 || p3.Equal(p1) != 1 {
+			t.Error("n*G != n*G (2)")
+		}
+		if p2.Equal(p3) != 1 || p3.Equal(p2) != 1 {
+			t.Error("n*G != n*G (3)")
+		}
+		p1.Add(p1, g)
+		if p1.Equal(g) != 0 || g.Equal(p1) != 0 {
+			t.Error("n*G == G")
+		}
+	}
+}
+
+func TestInfinity(t *testing.T) {
+	t.Run("P224", func(t *testing.T) {
+		testInfinity(t, nistec.NewP224Point, elliptic.P224())
+	})
+	t.Run("P256", func(t *testing.T) {
+		testInfinity(t, nistec.NewP256Point, elliptic.P256())
+	})
+	t.Run("P384", func(t *testing.T) {
+		testInfinity(t, nistec.NewP384Point, elliptic.P384())
+	})
+	t.Run("P521", func(t *testing.T) {
+		testInfinity(t, nistec.NewP521Point, elliptic.P521())
+	})
+}
+
+func testInfinity[P nistPointExtra[P]](t *testing.T, newPoint func() P, c elliptic.Curve) {
+	inf := newPoint()
+	g := newPoint().SetGenerator()
+	g.Add(g, g)
+	if inf.IsInfinity() != 1 {
+		t.Error("inf != inf")
+	}
+	if g.IsInfinity() != 0 {
+		t.Error("G == inf")
+	}
+	p1 := newPoint().Set(g)
+	p2 := newPoint()
+	sc := make([]byte, (c.Params().N.BitLen()+7)>>3)
+	for i := 1; i < 30; i++ {
+		sc[len(sc)-1] = byte(i)
+		_, err := p2.ScalarMult(g, sc)
+		fatalIfErr(t, err)
+		if p2.IsInfinity() != 0 {
+			t.Error("n*G == inf (1)")
+		}
+		p2.Negate(p2)
+		if p2.IsInfinity() != 0 {
+			t.Error("n*G == inf (2)")
+		}
+		p2.Add(p2, p1)
+		if p2.IsInfinity() != 1 {
+			t.Error("n*G - n*G != inf")
+		}
+		p1.Add(p1, g)
+		if p1.IsInfinity() != 0 {
+			t.Error("n*G == inf (3)")
+		}
 	}
 }


### PR DESCRIPTION
This PR adds the `IsInfinity()` and `Equal()` functions to the curves, with efficient and constant-time implementations.

Without these functions, these tests must be implemented by encoding points, which is inefficient (encoding a point entails normalization to affine, hence an inversion in the field) and not entirely constant-time (the point-at-infinity has a smaller encoding, so any encoding of that point will entail a memory access pattern different from that of a non-infinity point).